### PR TITLE
横幅が680pxを下回ったときに横並びを解除し上下となるように調整

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -46,14 +46,15 @@ html, body{
     height: 400px;
 }
 
+
 .container {
-    justify-content: center;
-    margin: auto;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    width: 50%;
-    height: 100%;
+  justify-content: center;
+  margin: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 50%;
+  height: 100%;
 }
 
 .tab_class {
@@ -95,3 +96,15 @@ input[name="tab_name"] {
   input:checked + .tab_class + .tab_content {
     display: block;
   }
+
+  @media screen and (max-width:680px) {
+    .container_wrapper{
+      display: block;
+      height: 800px;
+    }
+    .container {
+      width: 100%;
+      height: 50%;
+    }
+  }
+  


### PR DESCRIPTION
## 概要
横幅が680pxを下回ったときに横並びを解除し上下となるように調整

## 修正内容
コード例を見せる箇所を680pxで横並びと上下になるようにレスポンシブ対応しました。

## その他
サイトについて、スタイリングで手を加えたかった点が一つだけあったのでPRします。
アニメーションと実装を横並びで見せるのは横幅の狭いスマホだと厳しい予感。
画面の横幅680pxより大きい場合は作っていただいたとおりの表示、
画面の横幅680px以下は上下にしたほうが良いと思いました。
CSS追加しておきました。